### PR TITLE
Adding Yarn Workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,10 @@
 
 This is a [T3 Stack](https://create.t3.gg/) project bootstrapped with `create-t3-app`.
 
-## What's next? How do I make an app with this?
+## Working With Packages 
+Every package is located under `./packages`. The monorepo is configured with [Yarn Workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/). The setup intends you to interact with the packages from root level. To run a command in a package, simply run `yarn <package> <command>`, e.g. `yarn contracts test`.
 
-We try to keep this project as simple as possible, so you can start with just the scaffolding we set up for you, and add additional things later when they become necessary.
-
-If you are not familiar with the different technologies used in this project, please refer to the respective docs. If you still are in the wind, please join our [Discord](https://t3.gg/discord) and ask for help.
-
-- [Next.js](https://nextjs.org)
-- [NextAuth.js](https://next-auth.js.org)
-- [Prisma](https://prisma.io)
-- [Tailwind CSS](https://tailwindcss.com)
-- [tRPC](https://trpc.io)
-
-## Learn More
-
-To learn more about the [T3 Stack](https://create.t3.gg/), take a look at the following resources:
-
-- [Documentation](https://create.t3.gg/)
-- [Learn the T3 Stack](https://create.t3.gg/en/faq#what-learning-resources-are-currently-available) — Check out these awesome tutorials
-
-You can check out the [create-t3-app GitHub repository](https://github.com/t3-oss/create-t3-app) — your feedback and contributions are welcome!
-
-## How do I deploy this?
-
-Follow our deployment guides for [Vercel](https://create.t3.gg/en/deployment/vercel) and [Docker](https://create.t3.gg/en/deployment/docker) for more information.
+## Adding a New Package 
+1. add a folder under `./packages`
+2. add `./packages/<YOUR-PACKAGE>/package.json`-file with `{"name": "@pengekrukka/<YOUR-PACKAGE>", "version": "0.0.1", "private": true}`
+3. add `"<YOUR-PACKAGE>": "yarn workspace @pengekrukka/<YOUR-PACKAGE>"` under `"scripts"` in (root) `./package.json`. 

--- a/package.json
+++ b/package.json
@@ -1,38 +1,15 @@
 {
-  "name": "template",
-  "version": "0.1.0",
+  "workspaces": [
+    "packages/*"
+  ],
   "private": true,
   "scripts": {
-    "build": "next build",
-    "dev": "next dev",
-    "lint": "next lint",
-    "start": "next start"
+    "contracts": "yarn workspace @pengekrukka/contracts",
+    "webapp": "yarn workspace @pengekrukka/webapp"
   },
-  "dependencies": {
-    "@tanstack/react-query": "^4.16.0",
-    "@trpc/client": "^10.0.0",
-    "@trpc/next": "^10.0.0",
-    "@trpc/react-query": "^10.0.0",
-    "@trpc/server": "^10.0.0",
-    "next": "13.0.2",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "superjson": "1.9.1",
-    "zod": "^3.18.0"
-  },
-  "devDependencies": {
-    "@types/node": "^18.0.0",
-    "@types/react": "^18.0.14",
-    "@types/react-dom": "^18.0.5",
-    "@typescript-eslint/eslint-plugin": "^5.33.0",
-    "@typescript-eslint/parser": "^5.33.0",
-    "autoprefixer": "^10.4.7",
-    "eslint": "^8.26.0",
-    "eslint-config-next": "13.0.2",
-    "postcss": "^8.4.14",
-    "prettier": "^2.7.1",
-    "prettier-plugin-tailwindcss": "^0.1.13",
-    "tailwindcss": "^3.2.0",
-    "typescript": "^4.8.4"
+  "engines": {
+    "npm": "please-use-yarn",
+    "yarn": ">=1.22.0 <1.23.0",
+    "node": ">=16.0.0 <17.0.0"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,10 +1,15 @@
 {
-  "name": "hardhat-project",
-  "engines": {
-    "npm": "please-use-yarn",
-    "yarn": ">=1.22.0 <1.23.0",
-    "node": ">=16.0.0 <17.0.0"
+  "name": "@pengekrukka/contracts",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "test": "hardhat test",
+    "clean": "hardhat clean",
+    "compile": "hardhat compile",
+    "console": "hardhat console",
+    "typechain": "typechain --target ethers-v5 --out-dir build/types 'build/contracts/*.json'"
   },
+  "dependencies": {},
   "devDependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
@@ -35,13 +40,5 @@
     "typechain": "^8.1.1",
     "typescript": "^4.9.3",
     "ts-mocha": "^10.0.0"
-  },
-  "scripts": {
-    "test": "hardhat test",
-    "clean": "hardhat clean",
-    "compile": "hardhat compile",
-    "console": "hardhat console",
-    "typechain": "typechain --target ethers-v5 --out-dir build/types 'build/contracts/*.json'"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "template",
-  "version": "0.1.0",
+  "name": "@pengekrukka/webapp",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
Closes #19

This PR adds Yarn Workspaces and configures it such that commands in packages are executed from top level.
The idea here is that we never have to `cd` into different directories. Yarn Workspaces also allows us
to share the `node_modules`-folder.

In the future, I see us considering a system that syncs versions between packages and keeps _our_ versions
in sync as well. But that's a story for another time.

Concretely, this PR adds:
- yarn workspaces
- ability to run commands from top level through scripts in `./package.json`
- documentation of the above + how to add new packages
- removes unwanted dependencies in the top level `./package.json`
- renames packages with a `@pengekrukka`-prefix.