### PR TITLE
Debugging setup for webapp

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,5 +21,17 @@
             ],
             "type": "node"
         },
+        {
+            "name": "Next.js: debug full stack",
+            "type": "node-terminal",
+            "request": "launch",
+            "command": "yarn dev",
+            "cwd": "${workspaceFolder}/packages/webapp",
+            "serverReadyAction": {
+                "pattern": "started server on .+, url: (https?://.+)",
+                "uriFormat": "%s",
+                "action": "openExternally"
+            }
+        }
     ]
 }


### PR DESCRIPTION
This PR adds debugger for the webapp.
To start this in VSCode, simply run the run configuration
as described [here](https://code.visualstudio.com/docs/editor/debugging). This starts the webserver. Thereafter, you can set breakpoints in your code and inspect them when they're hit by running code.