### PR TITLE
Patch undefiend personalCredential being returned.

### DIFF
--- a/packages/webapp/src/server/trpc/router/wallet.ts
+++ b/packages/webapp/src/server/trpc/router/wallet.ts
@@ -45,7 +45,11 @@ export const walletRouter = router({
     const otherCredentials = otherCredentialsDB[userdid] ?? [];
     const personalCredential: VerifiableCredential = personalCredentialsDB[userdid]!!;
 
-    return [personalCredential, ...otherCredentials];
+    if (personalCredential) {
+      return [personalCredential, ...otherCredentials];
+    }
+
+    return otherCredentials;
   }),
   save: protectedProcedure.input(schemas.verifiableCredential).mutation(async ({ input, ctx }) => {
     const userdid = `did:ethr:${ctx.session.address}`;


### PR DESCRIPTION
I introduced a bug in #83 that caused `undefined` to be returned to the client as a `PersonCredential`. While this is only a patch and not a proper fix, I think it's okay in a hackathon-context. The underlying issue is not solved - The person credential should always be present after boot.